### PR TITLE
Fix dynamic app URL and terms link

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
       <button class="tabBtn btn btn-ghost" data-tab="browse">Browse & vote</button>
       <button class="tabBtn btn btn-ghost" data-tab="mine">My votes</button>
       <button class="tabBtn btn btn-ghost" data-tab="weekly">Weekly leaderboard</button>
-      <a class="ml-auto text-sm text-indigo-600 hover:underline" href="terms.html">Terms & Privacy</a>
+      <a class="ml-auto text-sm text-indigo-600 hover:underline" href="Terms_Privacy.html">Terms & Privacy</a>
     </div>
 
     <section id="tab-submit" class="tabPanel hidden fade">
@@ -108,8 +108,6 @@
     // =========================
     const SUPABASE_URL = 'https://ygbmgwzgascfiflaefwj.supabase.co';
     const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlnYm1nd3pnYXNjZmlmbGFlZndqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ3MTg5NDcsImV4cCI6MjA3MDI5NDk0N30.q0PxznHk83tXnaDZYbYQmlumGOk6TtPsXZG0jB0iweY';
-    // Your published GitHub Pages URL (with trailing slash)
-    const APP_URL = 'https://d2-hacking-report.github.io/D2-Crowdsourced-AntiCheat/';
     // Build APP_URL from the actual hosted path (fork/branch-safe). Always ends with '/'.
     const APP_URL = (() => {
       const u = new URL(window.location.href);


### PR DESCRIPTION
## Summary
- Fix duplicate APP_URL constant so authentication and report submission scripts run
- Update Terms link to match existing file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689706f4f1e883228a53713ee31bc0e2