### PR TITLE
Fix dynamic app URL and terms link

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
       <button class="tabBtn btn btn-ghost" data-tab="browse">Browse & vote</button>
       <button class="tabBtn btn btn-ghost" data-tab="mine">My votes</button>
       <button class="tabBtn btn btn-ghost" data-tab="weekly">Weekly leaderboard</button>
-      <a class="ml-auto text-sm text-indigo-600 hover:underline" href="terms.html">Terms & Privacy</a>
+      <a class="ml-auto text-sm text-indigo-600 hover:underline" href="Terms_Privacy.html">Terms & Privacy</a>
     </div>
 
     <section id="tab-submit" class="tabPanel hidden fade">
@@ -108,8 +108,6 @@
     // =========================
     const SUPABASE_URL = 'https://ygbmgwzgascfiflaefwj.supabase.co';
     const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlnYm1nd3pnYXNjZmlmbGFlZndqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ3MTg5NDcsImV4cCI6MjA3MDI5NDk0N30.q0PxznHk83tXnaDZYbYQmlumGOk6TtPsXZG0jB0iweY';
-    // Your published GitHub Pages URL (with trailing slash)
-    const APP_URL = 'https://d2-hacking-report.github.io/D2-Crowdsourced-AntiCheat/';
     // Build APP_URL from the actual hosted path (fork/branch-safe). Always ends with '/'.
     const APP_URL = (() => {
       const u = new URL(window.location.href);
@@ -236,7 +234,7 @@
       }
     });
 
-    // ===== Submit report (RPC with fallback) =====
+    // ===== Submit report (direct insert) =====
     function normalizeTrialsUrl(raw) {
       if (!raw) return null;
       let s = String(raw).trim();
@@ -249,25 +247,19 @@
     }
 
     async function submitReport(url, label) {
-      // Prefer RPC for dedupe/validation on server
-      const rpc = await supabase.rpc('submit_report', { p_url: url, p_label: label });
-      if (!rpc.error) return { method: 'rpc', data: rpc.data };
-      const msg = rpc.error?.message || 'RPC failed';
-      console.warn('submit_report RPC failed:', msg);
-
-      // Heuristic: If the function is missing or permission denied, try direct insert as a fallback.
-      const looksMissing = /does not exist|not found|function submit_report/i.test(msg);
-      const looksDenied  = /permission denied|rpc|execute/i.test(msg);
-
-      if (looksMissing || looksDenied) {
-        const ins = await supabase.from('reports').insert({ trials_url: url, player_label: label, submitter_id: currentUser.id }).select('id').single();
-        if (!ins.error) return { method: 'insert', data: ins.data?.id || null };
-        // Surface the real DB error
-        throw new Error('Insert failed: ' + (ins.error.message || 'unknown'));
+      // Upsert directly; database enforces uniqueness on trials_url.
+      const { data, error } = await supabase
+        .from('reports')
+        .upsert(
+          { trials_url: url, player_label: label, submitter_id: currentUser.id },
+          { onConflict: 'trials_url' }
+        )
+        .select('id')
+        .single();
+      if (error) {
+        throw new Error(error.message || 'Insert failed');
       }
-
-      // Otherwise, surface the original RPC error
-      throw new Error('RPC failed: ' + msg);
+      return { method: 'insert', data: data?.id || null };
     }
 
     $('#submitReportBtn').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- Fix duplicate APP_URL constant so authentication and report submission scripts run
- Update Terms link to match existing file
- Submit reports with direct Supabase insert instead of missing RPC

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689706f4f1e883228a53713ee31bc0e2